### PR TITLE
[APP-98459] implement open connector

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -340,6 +340,7 @@ func (q *statsQueryer) Query(query string, args []driver.Value) (driver.Rows, er
 }
 
 type statsQueryerContext struct {
+	driver.QueryerContext
 	*statsConnContext
 	wrapped driver.QueryerContext
 }
@@ -369,6 +370,7 @@ func (e *statsExecer) Exec(query string, args []driver.Value) (driver.Result, er
 }
 
 type statsExecerContext struct {
+	driver.ExecerContext
 	*statsConnContext
 	wrapped driver.ExecerContext
 }

--- a/driver.go
+++ b/driver.go
@@ -64,8 +64,6 @@ type statsDriver struct {
 }
 
 func (s *statsDriver) Open(name string) (driver.Conn, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "Open").Error("sappy func (s *statsDriver) Open(name string) (driver.Conn, error)")
 	c, err := s.wrapped.Open(name)
 	s.ConnOpened(err)
 	if err != nil {
@@ -89,76 +87,43 @@ func (s *statsDriver) Open(name string) (driver.Conn, error) {
 }
 
 func (s *statsDriver) OpenConnector(name string) (driver.Connector, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "Open").Error("sappy OpenConnector(name string)")
 	driverContext := s.wrapped.(driver.DriverContext)
 	c, err := driverContext.OpenConnector(name)
-	s.ConnOpened(err)
 	if err != nil {
 		return c, err
 	}
 	statc := &statsConnector{d: s, wrapped: c}
 	return statc, nil
-	// q, isQ := c.(driver.Queryer)
-	// e, isE := c.(driver.Execer)
-	// if isE && isQ {
-	// 	return &statsExecerQueryer{
-	// 		statsConn:    statc,
-	// 		statsQueryer: &statsQueryer{statsConn: statc, wrapped: q},
-	// 		statsExecer:  &statsExecer{statsConn: statc, wrapped: e},
-	// 	}, nil
-	// } else if isQ {
-	// 	return &statsQueryer{statsConn: statc, wrapped: q}, nil
-	// } else if isE {
-	// 	return &statsExecer{statsConn: statc, wrapped: e}, nil
-	// }
-	// return statc, nil
 }
 
-func (s *statsDriver) OpenContext(ctx context.Context, name string) (driver.Conn, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "Open").Error("sappy OpenContext(name string)")
-	driverContext := s.wrapped.(driver.DriverContext)
-	connector, err := driverContext.OpenConnector(name)
-	c, _ := connector.Connect(ctx)
-	s.ConnOpenedContext(ctx, err)
-	if err != nil {
-		return c, err
-	}
+// func (s *statsDriver) OpenContext(ctx context.Context, name string) (driver.Conn, error) {
+// 	// mockCTX := ctx17.Background()
+// 	// mockCTX.WithField("sappy", "Open").Error("sappy OpenContext(name string)")
+// 	driverContext := s.wrapped.(driver.DriverContext)
+// 	connector, err := driverContext.OpenConnector(name)
+// 	c, _ := connector.Connect(ctx)
+// 	s.ConnOpenedContext(ctx, err)
+// 	if err != nil {
+// 		return c, err
+// 	}
 
-	statc := &statsConnContext{d: s, wrapped: c}
-	q, isQ := c.(driver.QueryerContext)
-	// return &statsQueryerContext{statsConnContext: statc, wrapped: q}, nil
-	e, isE := c.(driver.ExecerContext)
-	if isE && isQ {
-		return &statsExecerQueryerContext{
-			statsConnContext:    statc,
-			statsQueryerContext: &statsQueryerContext{statsConnContext: statc, wrapped: q},
-			statsExecerContext:  &statsExecerContext{statsConnContext: statc, wrapped: e},
-		}, nil
-	} else if isQ {
-		return &statsQueryerContext{statsConnContext: statc, wrapped: q}, nil
-	} else if isE {
-		return &statsExecerContext{statsConnContext: statc, wrapped: e}, nil
-	}
-	return statc, nil
+// 	statc := &statsConnContext{d: s, wrapped: c}
+// 	q, isQ := c.(driver.QueryerContext)
+// 	e, isE := c.(driver.ExecerContext)
+// 	if isE && isQ {
+// 		return &statsExecerQueryerContext{
+// 			statsConnContext:    statc,
+// 			statsQueryerContext: &statsQueryerContext{statsConnContext: statc, wrapped: q},
+// 			statsExecerContext:  &statsExecerContext{statsConnContext: statc, wrapped: e},
+// 		}, nil
+// 	} else if isQ {
+// 		return &statsQueryerContext{statsConnContext: statc, wrapped: q}, nil
+// 	} else if isE {
+// 		return &statsExecerContext{statsConnContext: statc, wrapped: e}, nil
+// 	}
+// 	return statc, nil
 
-	// statc := &statsConn{d: s, wrapped: c}
-	// q, isQ := c.(driver.Queryer)
-	// e, isE := c.(driver.Execer)
-	// if isE && isQ {
-	// 	return &statsExecerQueryer{
-	// 		statsConn:    statc,
-	// 		statsQueryer: &statsQueryer{statsConn: statc, wrapped: q},
-	// 		statsExecer:  &statsExecer{statsConn: statc, wrapped: e},
-	// 	}, nil
-	// } else if isQ {
-	// 	return &statsQueryer{statsConn: statc, wrapped: q}, nil
-	// } else if isE {
-	// 	return &statsExecer{statsConn: statc, wrapped: e}, nil
-	// }
-	// return statc, nil
-}
+// }
 
 func (s *statsDriver) AddHook(h Hook) {
 	s.hooks = append(s.hooks, h)
@@ -270,8 +235,6 @@ type statsConnector struct {
 }
 
 func (conn *statsConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "debug").Error("sappy debug func (conn *statsConnector) Connect(ctx context.Context) (driver.Conn, error)")
 	c, err := conn.wrapped.Connect(ctx)
 	conn.d.ConnOpenedContext(ctx, err)
 	if err != nil {
@@ -280,7 +243,6 @@ func (conn *statsConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	statc := &statsConnContext{d: conn.d, wrapped: c}
 	q, isQ := c.(driver.QueryerContext)
-	// return &statsQueryerContext{statsConnContext: statc, wrapped: q}, nil
 	e, isE := c.(driver.ExecerContext)
 	if isE && isQ {
 		return &statsExecerQueryerContext{
@@ -404,12 +366,10 @@ type statsQueryer struct {
 }
 
 func (q *statsQueryer) Query(query string, args []driver.Value) (driver.Rows, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "Query").Error("sappy Query")
 	start := time.Now()
-	r, err := q.wrapped.Query(query, args) // 真正執行
+	r, err := q.wrapped.Query(query, args)
 	dur := time.Now().Sub(start)
-	q.statsConn.d.Queried(dur, query, err) // sappy: 印出來
+	q.statsConn.d.Queried(dur, query, err)
 	if err == nil {
 		r = &statsRows{d: q.statsConn.d, wrapped: r}
 	}
@@ -422,8 +382,6 @@ type statsQueryerContext struct {
 }
 
 func (q *statsQueryerContext) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "QueryContext").Error("sappy QueryContext")
 	start := time.Now()
 	r, err := q.wrapped.QueryContext(ctx, query, args)
 	dur := time.Now().Sub(start)
@@ -453,8 +411,6 @@ type statsExecerContext struct {
 }
 
 func (e *statsExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	// mockCTX := ctx17.Background()
-	// mockCTX.WithField("sappy", "ExecContext").Error("sappy ExecContext")
 	start := time.Now()
 	r, err := e.wrapped.ExecContext(ctx, query, args)
 	dur := time.Now().Sub(start)

--- a/driver.go
+++ b/driver.go
@@ -53,14 +53,12 @@ type Driver interface {
 	AddHook(h Hook)
 }
 
-func New(open OpenFunc, openConnector OpenConnectorFunc, wrapped driver.Driver) Driver {
-	return &statsDriver{open: open, openConnector: openConnector, wrapped: wrapped}
+func New(wrapped driver.Driver) Driver {
+	return &statsDriver{wrapped: wrapped}
 }
 
 type statsDriver struct {
-	open          OpenFunc
-	openConnector OpenConnectorFunc
-	wrapped       driver.Driver
+	wrapped driver.Driver
 
 	hooks []Hook
 }
@@ -68,7 +66,7 @@ type statsDriver struct {
 func (s *statsDriver) Open(name string) (driver.Conn, error) {
 	// mockCTX := ctx17.Background()
 	// mockCTX.WithField("sappy", "Open").Error("sappy func (s *statsDriver) Open(name string) (driver.Conn, error)")
-	c, err := s.open(name)
+	c, err := s.wrapped.Open(name)
 	s.ConnOpened(err)
 	if err != nil {
 		return c, err

--- a/driver.go
+++ b/driver.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"io"
 	"time"
-	// ctx17 "github.com/17media/api/base/ctx"
 )
 
 // Hook is an interface through which database events can be received. A Hook may received

--- a/driver.go
+++ b/driver.go
@@ -8,13 +8,6 @@ import (
 	// ctx17 "github.com/17media/api/base/ctx"
 )
 
-// OpenFunc is the func used on driver.Driver. This is used as some driver libraries
-// (lib/pq for example) do not expose their driver.Driver struct, but do expose an Open
-// function.
-type OpenFunc func(name string) (driver.Conn, error)
-
-type OpenConnectorFunc func(name string) (driver.Connector, error)
-
 // Hook is an interface through which database events can be received. A Hook may received
 // multiple events concurrently. Each function's last argument is of type error which will
 // contain an error encountered while trying to perform the action. The one exception is

--- a/driver.go
+++ b/driver.go
@@ -96,35 +96,6 @@ func (s *statsDriver) OpenConnector(name string) (driver.Connector, error) {
 	return statc, nil
 }
 
-// func (s *statsDriver) OpenContext(ctx context.Context, name string) (driver.Conn, error) {
-// 	// mockCTX := ctx17.Background()
-// 	// mockCTX.WithField("sappy", "Open").Error("sappy OpenContext(name string)")
-// 	driverContext := s.wrapped.(driver.DriverContext)
-// 	connector, err := driverContext.OpenConnector(name)
-// 	c, _ := connector.Connect(ctx)
-// 	s.ConnOpenedContext(ctx, err)
-// 	if err != nil {
-// 		return c, err
-// 	}
-
-// 	statc := &statsConnContext{d: s, wrapped: c}
-// 	q, isQ := c.(driver.QueryerContext)
-// 	e, isE := c.(driver.ExecerContext)
-// 	if isE && isQ {
-// 		return &statsExecerQueryerContext{
-// 			statsConnContext:    statc,
-// 			statsQueryerContext: &statsQueryerContext{statsConnContext: statc, wrapped: q},
-// 			statsExecerContext:  &statsExecerContext{statsConnContext: statc, wrapped: e},
-// 		}, nil
-// 	} else if isQ {
-// 		return &statsQueryerContext{statsConnContext: statc, wrapped: q}, nil
-// 	} else if isE {
-// 		return &statsExecerContext{statsConnContext: statc, wrapped: e}, nil
-// 	}
-// 	return statc, nil
-
-// }
-
 func (s *statsDriver) AddHook(h Hook) {
 	s.hooks = append(s.hooks, h)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sappychi/dbstats
+module github.com/17media/dbstats
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/17media/dbstats
+module github.com/sappychi/dbstats
 
 go 1.13


### PR DESCRIPTION
Jira Ticket: [APP-98459](https://17media.atlassian.net/browse/APP-98459)

- [ ] Read [Code Review Policy](https://github.com/17media/wiki/blob/master/pages/Backend/code-review.md)!

<!--- Provide a general summary of your changes in the Title above -->

Support Context for  SQL Driver.
This PR should work with this PR. 
https://github.com/17media/dbstats/pull/4

## Description
<!--- Describe your changes in detail -->
我們需要讓 SQL Driver 支援 context，以及 context timeout
需要實作 DriverContext 這個 interface - `OpenConnector(dsn string)` 以及 Connector 對應的功能

這個 PR 主要是
1. 實作 [dbstats driver](https://github.com/17media/dbstats/pull/4) 的 `OpenConnector(dsn string)` 以及 Connector 對應的功能 (OpenContext, QueryContext, etc.)
2. 傳入整個 sql driver 到 sqlswitch driver, dbstats driver上，讓 sqlswitch/dbstats 直接使用 driver 的相關函式



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- JIRA ticket / spec doc / slack link -->

[APP-98459]: https://17media.atlassian.net/browse/APP-98459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ